### PR TITLE
Fix Android USB implementation

### DIFF
--- a/examples/android/FlashToolTest/.gitignore
+++ b/examples/android/FlashToolTest/.gitignore
@@ -87,6 +87,7 @@ obj/
 .idea/misc.xml
 .idea/gradle.xml
 .idea/runConfigurations.xml
+.idea/codeStyles/Project.xml
 
 # OS-specific files
 .DS_Store


### PR DESCRIPTION
Android USB was using the same boolean in two different threads (reported on issue #16).
Also, the LinkedList was replaced by ArrayDeque.

Fix #16
Fix #14