### PR TITLE
Fix initialization of signed long variables

### DIFF
--- a/jocd/src/br/org/certi/jocd/coresight/AccessPort.java
+++ b/jocd/src/br/org/certi/jocd/coresight/AccessPort.java
@@ -48,21 +48,21 @@ public class AccessPort {
   }
 
   // AP Control and Status Word definitions
-  public static final long CSW_SIZE = 0x00000007;
-  public static final long CSW_SIZE8 = 0x00000000;
-  public static final long CSW_SIZE16 = 0x00000001;
-  public static final long CSW_SIZE32 = 0x00000002;
-  public static final long CSW_ADDRINC = 0x00000030;
-  public static final long CSW_NADDRINC = 0x00000000;
-  public static final long CSW_SADDRINC = 0x00000010;
-  public static final long CSW_PADDRINC = 0x00000020;
-  public static final long CSW_DBGSTAT = 0x00000040;
-  public static final long CSW_TINPROG = 0x00000080;
-  public static final long CSW_HPROT = 0x02000000;
-  public static final long CSW_MSTRTYPE = 0x20000000;
-  public static final long CSW_MSTRCORE = 0x00000000;
-  public static final long CSW_MSTRDBG = 0x20000000;
-  public static final long CSW_RESERVED = 0x01000000;
+  public static final long CSW_SIZE = 0x00000007L;
+  public static final long CSW_SIZE8 = 0x00000000L;
+  public static final long CSW_SIZE16 = 0x00000001L;
+  public static final long CSW_SIZE32 = 0x00000002L;
+  public static final long CSW_ADDRINC = 0x00000030L;
+  public static final long CSW_NADDRINC = 0x00000000L;
+  public static final long CSW_SADDRINC = 0x00000010L;
+  public static final long CSW_PADDRINC = 0x00000020L;
+  public static final long CSW_DBGSTAT = 0x00000040L;
+  public static final long CSW_TINPROG = 0x00000080L;
+  public static final long CSW_HPROT = 0x02000000L;
+  public static final long CSW_MSTRTYPE = 0x20000000L;
+  public static final long CSW_MSTRCORE = 0x00000000L;
+  public static final long CSW_MSTRDBG = 0x20000000L;
+  public static final long CSW_RESERVED = 0x01000000L;
 
   public static final long CSW_VALUE = (CSW_RESERVED | CSW_MSTRDBG | CSW_HPROT | CSW_DBGSTAT
       | CSW_SADDRINC);
@@ -77,9 +77,9 @@ public class AccessPort {
   }
 
   // Debug Exception and Monitor Control Register
-  public static final long DEMCR = 0xE000EDFC;
+  public static final long DEMCR = 0xE000EDFCL;
   // DWTENA in armv6 architecture reference manual
-  public static final long DEMCR_TRCENA = (1 << 24);
+  public static final long DEMCR_TRCENA = (0x1L << 24);
 
   public DebugPort dp;
   public int apNum;
@@ -108,9 +108,9 @@ public class AccessPort {
       // Init ROM table
       this.romAddr = this.readRegNow(AP_ROM_TABLE_ADDR_REG);
       this.hasRomTable =
-          (this.romAddr != 0xFFFFFFFF) && ((this.romAddr & AP_ROM_TABLE_ENTRY_PRESENT_MASK) != 0);
+          (this.romAddr != 0xFFFFFFFFL) && ((this.romAddr & AP_ROM_TABLE_ENTRY_PRESENT_MASK) != 0);
       // Clear format and present bits
-      this.romAddr &= 0xFFFFFFFC;
+      this.romAddr &= 0xFFFFFFFCL;
       this.initedPrimary = true;
     }
 

--- a/jocd/src/br/org/certi/jocd/coresight/CoreSightComponent.java
+++ b/jocd/src/br/org/certi/jocd/coresight/CoreSightComponent.java
@@ -28,37 +28,37 @@ public class CoreSightComponent {
   private final static String CLASS_NAME = CoreSightComponent.class.getName();
   private final static Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
-  public static final long PIDR4 = 0xFD0;
-  public static final long PIDR0 = 0xFE0;
-  public static final long CIDR0 = 0xFF0;
-  public static final long DEVTYPE = 0xFCC;
-  public static final long DEVID = 0xFC8;
+  public static final long PIDR4 = 0xFD0L;
+  public static final long PIDR0 = 0xFE0L;
+  public static final long CIDR0 = 0xFF0L;
+  public static final long DEVTYPE = 0xFCCL;
+  public static final long DEVID = 0xFC8L;
   public static final int IDR_COUNT = 12;
   public static final int PIDR4_OFFSET = 0;
   public static final int PIDR0_OFFSET = 4;
   public static final int CIDR0_OFFSET = 8;
 
-  public static final long CIDR_PREAMBLE_MASK = 0xFFFF0FFF;
-  public static final long CIDR_PREAMBLE_VALUE = 0xB105000D;
+  public static final long CIDR_PREAMBLE_MASK = 0xFFFF0FFFL;
+  public static final long CIDR_PREAMBLE_VALUE = 0xB105000DL;
 
-  public static final long CIDR_COMPONENT_CLASS_MASK = 0xF000;
-  public static final long CIDR_COMPONENT_CLASS_SHIFT = 12;
+  public static final long CIDR_COMPONENT_CLASS_MASK = 0xF000L;
+  public static final int CIDR_COMPONENT_CLASS_SHIFT = 12;
 
-  public static final long CIDR_ROM_TABLE_CLASS = 0x1;
-  public static final long CIDR_CORESIGHT_CLASS = 0x9;
+  public static final long CIDR_ROM_TABLE_CLASS = 0x1L;
+  public static final long CIDR_CORESIGHT_CLASS = 0x9L;
 
   public static final long PIDR_4KB_COUNT_MASK = 0xF000000000L;
-  public static final long PIDR_4KB_COUNT_SHIFT = 36;
+  public static final int PIDR_4KB_COUNT_SHIFT = 36;
 
-  public static final long ROM_TABLE_ENTRY_PRESENT_MASK = 0x1;
+  public static final long ROM_TABLE_ENTRY_PRESENT_MASK = 0x1L;
 
   // Mask for ROM table entry size. 1 if 32-bit, 0 if 8-bit.
-  public static final long ROM_TABLE_32BIT_MASK = 0x2;
+  public static final long ROM_TABLE_32BIT_MASK = 0x2L;
 
   // 2's complement offset to debug component from ROM table base address.
-  public static final long ROM_TABLE_ADDR_OFFSET_NEG_MASK = 0x80000000;
-  public static final long ROM_TABLE_ADDR_OFFSET_MASK = 0xFFFFF000;
-  public static final long ROM_TABLE_ADDR_OFFSET_SHIFT = 12;
+  public static final long ROM_TABLE_ADDR_OFFSET_NEG_MASK = 0x80000000L;
+  public static final long ROM_TABLE_ADDR_OFFSET_MASK = 0xFFFFF000L;
+  public static final int ROM_TABLE_ADDR_OFFSET_SHIFT = 12;
 
   // 9 entries is enough entries to cover the standard Cortex-M4 ROM table for devices with ETM.
   public static final int ROM_TABLE_ENTRY_READ_COUNT = 9;

--- a/jocd/src/br/org/certi/jocd/coresight/CortexM.java
+++ b/jocd/src/br/org/certi/jocd/coresight/CortexM.java
@@ -151,7 +151,7 @@ public class CortexM extends Target {
   }
 
   // Debug Fault Status Register
-  public static final long DFSR = 0xE000ED30;
+  public static final long DFSR = 0xE000ED30L;
   public static final int DFSR_EXTERNAL = (1 << 4);
   public static final int DFSR_VCATCH = (1 << 3);
   public static final int DFSR_DWTTRAP = (1 << 2);
@@ -159,7 +159,7 @@ public class CortexM extends Target {
   public static final int DFSR_HALTED = (1 << 0);
 
   // Debug Exception and Monitor Control Register
-  public static final long DEMCR = 0xE000EDFC;
+  public static final long DEMCR = 0xE000EDFCL;
   // DWTENA in armv6 architecture reference manual
   public static final int DEMCR_TRCENA = (1 << 24);
   public static final int DEMCR_VC_HARDERR = (1 << 10);
@@ -172,18 +172,18 @@ public class CortexM extends Target {
   public static final int DEMCR_VC_CORERESET = (1 << 0);
 
   // CPUID Register
-  public static final long CPUID = 0xE000ED00;
+  public static final long CPUID = 0xE000ED00L;
 
   // CPUID masks
-  public static final long CPUID_IMPLEMENTER_MASK = 0xff000000;
+  public static final long CPUID_IMPLEMENTER_MASK = 0xFF000000L;
   public static final int CPUID_IMPLEMENTER_POS = 24;
-  public static final long CPUID_VARIANT_MASK = 0x00f00000;
+  public static final long CPUID_VARIANT_MASK = 0x00F00000L;
   public static final int CPUID_VARIANT_POS = 20;
-  public static final long CPUID_ARCHITECTURE_MASK = 0x000f0000;
+  public static final long CPUID_ARCHITECTURE_MASK = 0x000F0000L;
   public static final int CPUID_ARCHITECTURE_POS = 16;
-  public static final long CPUID_PARTNO_MASK = 0x0000fff0;
+  public static final long CPUID_PARTNO_MASK = 0x0000FFF0L;
   public static final int CPUID_PARTNO_POS = 4;
-  public static final long CPUID_REVISION_MASK = 0x0000000f;
+  public static final long CPUID_REVISION_MASK = 0x0000000FL;
   public static final int CPUID_REVISION_POS = 0;
 
   public static final int CPUID_IMPLEMENTER_ARM = 0x41;
@@ -191,12 +191,12 @@ public class CortexM extends Target {
   public static final int ARMv7M = 0xF;
 
   // Debug Core Register Selector Register
-  public static final long DCRSR = 0xE000EDF4;
+  public static final long DCRSR = 0xE000EDF4L;
   public static final long DCRSR_REGWnR = (1 << 16);
-  public static final long DCRSR_REGSEL = 0x1F;
+  public static final long DCRSR_REGSEL = 0x1FL;
 
   // Debug Halting Control and Status Register
-  public static final long DHCSR = 0xE000EDF0;
+  public static final long DHCSR = 0xE000EDF0L;
   public static final int C_DEBUGEN = (1 << 0);
   public static final int C_HALT = (1 << 1);
   public static final int C_STEP = (1 << 2);
@@ -210,18 +210,18 @@ public class CortexM extends Target {
   public static final int S_RESET_ST = (1 << 25);
 
   // Debug Core Register Data Register
-  public static final long DCRDR = 0xE000EDF8;
+  public static final long DCRDR = 0xE000EDF8L;
 
   // Coprocessor Access Control Register
-  public static final long CPACR = 0xE000ED88;
+  public static final long CPACR = 0xE000ED88L;
   public static final int CPACR_CP10_CP11_MASK = (3 << 20) | (3 << 22);
 
-  public static final long NVIC_AIRCR = 0xE000ED0C;
-  public static final int NVIC_AIRCR_VECTKEY = (0x5FA << 16);
+  public static final long NVIC_AIRCR = 0xE000ED0CL;
+  public static final long NVIC_AIRCR_VECTKEY = (0x5FAL << 16);
   public static final int NVIC_AIRCR_VECTRESET = (1 << 0);
   public static final int NVIC_AIRCR_SYSRESETREQ = (1 << 2);
 
-  public static final int DBGKEY = (0xA05F << 16);
+  public static final long DBGKEY = (0xA05FL << 16);
 
   private int runToken = 0;
 
@@ -712,8 +712,8 @@ public class CortexM extends Target {
         // Mask in the new special register value so we don't modify the other register values that
         // share the same DCRSR number.
         int shift = (-(reg.getValue()) - 1) * 8;
-        long mask = 0xffffffff ^ (0xff << shift);
-        word = (specialRegValue & mask) | ((word & 0xff) << shift);
+        long mask = 0xFFFFFFFFL ^ (0xFFL << shift);
+        word = (specialRegValue & mask) | ((word & 0xFFL) << shift);
         // Update special register for other writes that might be in the list.
         specialRegValue = word;
         reg = CortexMRegister.CFBP;

--- a/jocd/src/br/org/certi/jocd/coresight/DebugPort.java
+++ b/jocd/src/br/org/certi/jocd/coresight/DebugPort.java
@@ -70,9 +70,9 @@ public class DebugPort {
   }
 
   // DP Control / Status Register bit definitions
-  private static final long CTRLSTAT_STICKYORUN = 0x00000002;
-  private static final long CTRLSTAT_STICKYCMP = 0x00000010;
-  private static final long CTRLSTAT_STICKYERR = 0x00000020;
+  private static final long CTRLSTAT_STICKYORUN = 0x00000002L;
+  private static final long CTRLSTAT_STICKYCMP = 0x00000010L;
+  private static final long CTRLSTAT_STICKYERR = 0x00000020L;
 
   public static final byte IDCODE = 0 << 2;
   public static final byte AP_ACC = 1 << 0;
@@ -84,21 +84,21 @@ public class DebugPort {
 
   public static final byte A32 = (byte) 0x0C;
   public static final int APSEL_SHIFT = 24;
-  public static final long APSEL = 0xFF000000;
-  public static final long APBANKSEL = 0x000000F0;
-  public static final long APREG_MASK = 0x000000FC;
+  public static final long APSEL = 0xFF000000L;
+  public static final long APBANKSEL = 0x000000F0L;
+  public static final long APREG_MASK = 0x000000FCL;
 
-  private static final long DPIDR_MIN_MASK = 0x10000;
-  private static final long DPIDR_VERSION_MASK = 0xF000;
+  private static final long DPIDR_MIN_MASK = 0x10000L;
+  private static final long DPIDR_VERSION_MASK = 0xF000L;
   private static final int DPIDR_VERSION_SHIFT = 12;
 
-  private static final long CSYSPWRUPACK = 0x80000000;
-  private static final long CDBGPWRUPACK = 0x20000000;
-  private static final long CSYSPWRUPREQ = 0x40000000;
-  private static final long CDBGPWRUPREQ = 0x10000000;
+  private static final long CSYSPWRUPACK = 0x80000000L;
+  private static final long CDBGPWRUPACK = 0x20000000L;
+  private static final long CSYSPWRUPREQ = 0x40000000L;
+  private static final long CDBGPWRUPREQ = 0x10000000L;
 
-  private static final long TRNNORMAL = 0x00000000;
-  private static final long MASKLANE = 0x00000F00;
+  private static final long TRNNORMAL = 0x00000000L;
+  private static final long MASKLANE = 0x00000F00L;
 
   private DapAccessCmsisDap link;
   private HashMap<Long, Long> csw = new HashMap<>();

--- a/jocd/src/br/org/certi/jocd/coresight/MemAp.java
+++ b/jocd/src/br/org/certi/jocd/coresight/MemAp.java
@@ -155,9 +155,9 @@ public class MemAp extends AccessPort {
     try {
       this.dp.readAPAsync(transfer, numDp);
       if (transferSize == 8) {
-        res = (res >> ((addr & 0x03) << 3) & 0xFF);
+        res = (res >> ((addr & 0x03L) << 3) & 0xFFL);
       } else if (transferSize == 16) {
-        res = (res >> ((addr & 0x02) << 3) & 0xFFFF);
+        res = (res >> ((addr & 0x02L) << 3) & 0xFFFFL);
       }
     } catch (TransferFaultError error) {
       // Annotate error with target address.
@@ -386,7 +386,7 @@ public class MemAp extends AccessPort {
     while (size > 0) {
       long n = this.autoIncrementPageSize - (addr & (this.autoIncrementPageSize - 1));
       if (size * 4 < n) {
-        n = (size * 4) & 0xFFFFFFFC;
+        n = (size * 4) & 0xFFFFFFFCL;
       }
       this.writeBlock32(addr, Util.getSubArray(data, 0, (int) (n / 4)));
       Util.getSubArray(data, (int) (n / 4), null);
@@ -405,7 +405,7 @@ public class MemAp extends AccessPort {
     while (size > 0) {
       long n = this.autoIncrementPageSize - (addr & (this.autoIncrementPageSize - 1));
       if (size * 4 < n) {
-        n = (size * 4) & 0xFFFFFFFC;
+        n = (size * 4) & 0xFFFFFFFCL;
       }
       resp = Util.appendDataInArray(resp, this.readBlock32(addr, (int) n / 4));
       size -= n / 4;

--- a/jocd/src/br/org/certi/jocd/dapaccess/CmsisDapProtocol.java
+++ b/jocd/src/br/org/certi/jocd/dapaccess/CmsisDapProtocol.java
@@ -355,10 +355,10 @@ public class CmsisDapProtocol {
   public byte setSWJClock(int clock) throws DeviceError, TimeoutException, Error {
     byte[] cmd = new byte[5];
     cmd[0] = CommandId.DAP_SWJ_CLOCK.getValue();
-    cmd[1] = (byte) (clock & 0xff);
-    cmd[2] = (byte) ((clock >> 8) & 0xff);
-    cmd[3] = (byte) ((clock >> 16) & 0xff);
-    cmd[4] = (byte) ((clock >> 24) & 0xff);
+    cmd[1] = (byte) (clock & 0xFF);
+    cmd[2] = (byte) ((clock >> 8) & 0xFF);
+    cmd[3] = (byte) ((clock >> 16) & 0xFF);
+    cmd[4] = (byte) ((clock >> 24) & 0xFF);
     this.connectionInterface.write(cmd);
 
     byte[] response = this.connectionInterface.read();
@@ -389,12 +389,12 @@ public class CmsisDapProtocol {
       LOGGER.log(Level.SEVERE, String.format("Cannot find %s pin", pin));
       return null;
     }
-    cmd[1] = (byte) (output & 0xff);
+    cmd[1] = (byte) (output & 0xFF);
     cmd[2] = p;
-    cmd[3] = (byte) (wait & 0xff);
-    cmd[4] = (byte) ((wait >> 8) & 0xff);
-    cmd[5] = (byte) ((wait >> 16) & 0xff);
-    cmd[6] = (byte) ((wait >> 24) & 0xff);
+    cmd[3] = (byte) (wait & 0xFF);
+    cmd[4] = (byte) ((wait >> 8) & 0xFF);
+    cmd[5] = (byte) ((wait >> 16) & 0xFF);
+    cmd[6] = (byte) ((wait >> 24) & 0xFF);
     this.connectionInterface.write(cmd);
 
     byte[] resp = this.connectionInterface.read();

--- a/jocd/src/br/org/certi/jocd/flash/FlashBuilder.java
+++ b/jocd/src/br/org/certi/jocd/flash/FlashBuilder.java
@@ -393,7 +393,7 @@ public class FlashBuilder {
         data = Util.fillArray(data, (int) page.size, (byte) 0xFF);
         CRC32 crc = new CRC32();
         crc.update(data);
-        page.crc = (int) (crc.getValue() & 0xFFFFFFFF);
+        page.crc = (int) (crc.getValue() & 0xFFFFFFFFL);
       }
     }
 

--- a/jocd/src/br/org/certi/jocd/target/nrf51822/FlashNrf51.java
+++ b/jocd/src/br/org/certi/jocd/target/nrf51822/FlashNrf51.java
@@ -29,7 +29,7 @@ public class FlashNrf51 extends Flash {
    */
   public FlashNrf51(Target target) {
     this.flashAlgo = new FlashAlgo();
-    this.flashAlgo.loadAddress = 0x20000000;
+    this.flashAlgo.loadAddress = 0x20000000L;
     this.flashAlgo.instructions = new long[]{0xE00ABE00L, 0x062D780DL, 0x24084068L, 0xD3000040L,
         0x1E644058L, 0x1C49D1FAL, 0x2A001E52L, 0x4770D1F2L, 0x47702000L, 0x47702000L, 0x4C26B570L,
         0x60602002L, 0x60E02001L, 0x68284D24L, 0xD00207C0L, 0x60602000L, 0xF000BD70L, 0xE7F6F82CL,
@@ -39,18 +39,18 @@ public class FlashNrf51 extends Flash {
         0x480CE7F2L, 0x06006840L, 0xD00B0E00L, 0x6849490AL, 0xD0072900L, 0x4A0A4909L, 0xD00007C3L,
         0x1D09600AL, 0xD1F90840L, 0x00004770L, 0x4001E500L, 0x4001E400L, 0x10001000L, 0x40010400L,
         0x40010500L, 0x40010600L, 0x6E524635L, 0x00000000L};
-    this.flashAlgo.pcInit = 0x20000021;
-    this.flashAlgo.pcEraseAll = 0x20000029;
-    this.flashAlgo.pcEraseSector = 0x20000049;
-    this.flashAlgo.pcProgramPage = 0x20000071;
-    this.flashAlgo.beginData = 0x20002000; // Analyzer uses a max of 1 KB data (256 pages * 4 bytes / page)
+    this.flashAlgo.pcInit = 0x20000021L;
+    this.flashAlgo.pcEraseAll = 0x20000029L;
+    this.flashAlgo.pcEraseSector = 0x20000049L;
+    this.flashAlgo.pcProgramPage = 0x20000071L;
+    this.flashAlgo.beginData = 0x20002000L; // Analyzer uses a max of 1 KB data (256 pages * 4 bytes / page)
     this.flashAlgo.pageBuffers = Arrays
-        .asList((long) 0x20002000, (long) 0x20002400); // Enable double buffering
-    this.flashAlgo.beginStack = 0x20001000;
-    this.flashAlgo.staticBase = 0x20000170;
+        .asList(0x20002000L, 0x20002400L); // Enable double buffering
+    this.flashAlgo.beginStack = 0x20001000L;
+    this.flashAlgo.staticBase = 0x20000170L;
     this.flashAlgo.minProgramLength = 4;
     this.flashAlgo.analyzerSupported = true;
-    this.flashAlgo.analyzerAddress = 0x20003000; // Analyzer 0x20003000..0x20003600
+    this.flashAlgo.analyzerAddress = 0x20003000L; // Analyzer 0x20003000..0x20003600
 
     super.setup(target, flashAlgo);
   }

--- a/jocd/src/br/org/certi/jocd/target/nrf51822/Nrf51.java
+++ b/jocd/src/br/org/certi/jocd/target/nrf51822/Nrf51.java
@@ -36,7 +36,7 @@ public class Nrf51 extends CoreSightTarget {
   private final static Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
   // nRF51 specific registers
-  int reset;
+  long reset;
   int resetEnable;
 
   /*
@@ -68,7 +68,7 @@ public class Nrf51 extends CoreSightTarget {
 
     memoryMap = new MemoryMap(memoryRegions);
 
-    this.reset = 0x40000544;
+    this.reset = 0x40000544L;
     this.resetEnable = (1 << 0);
 
     super.setup(link, memoryMap);


### PR DESCRIPTION
The values inserted on initialization of long variables ar treated as integer.
So, it will automaticly makes a convertion from signed integer to signed long if the value is inserted without the letter "L" at the end of the value.

An  "long var = 0x80000000" would be converted to "0xFFFFFFFF80000000" (long) leading to errors when bitwise operations is performed.