### PR TITLE
Fix memory region detection from IntexHex

### DIFF
--- a/third-party/java-intelhex-parser/src/cz/jaybee/intelhex/Parser.java
+++ b/third-party/java-intelhex-parser/src/cz/jaybee/intelhex/Parser.java
@@ -217,6 +217,10 @@ public class Parser {
         String recordStr;
 
         while ((recordStr = reader.readLine()) != null) {
+            // Ignore if this is a blank line.
+            if (recordStr.isEmpty()) {
+                continue;
+            }
             Record record = parseRecord(recordStr);
             processRecord(record);
             recordIdx++;


### PR DESCRIPTION
Instead of just detecting each range from IntelHex now it groups the data into contiguous memory range before passing to FlashBuilder.